### PR TITLE
Normative: Remove @@species from WeakRef and FinalizationGroup

### DIFF
--- a/spec/finalization-group.html
+++ b/spec/finalization-group.html
@@ -75,31 +75,6 @@
         [[Enumerable]]: *false*, [[Configurable]]: *false* }.
       </p>
     </emu-clause>
-
-    <emu-clause id="sec-get-finalization-group-@@species">
-      <h1>get FinalizationGroup [ @@species ]</h1>
-
-      <p>
-        `FinalizationGroup[@@species]` is an accessor property whose
-        set accessor function is *undefined*. Its get accessor
-        function performs the following steps:
-      </p>
-
-      <emu-alg>
-        1. Return the *this* value.
-      </emu-alg>
-      <p>
-        The value of the `name` property of this function is `"get [Symbol.species]"`.
-      </p>
-      <emu-note>
-        <p>
-          Methods that create derived collection objects should call
-          @@species to determine the constructor to use to create the
-          derived objects. Subclass constructor may over-ride
-          @@species to change the default constructor assignment.
-        </p>
-      </emu-note>
-    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-properties-of-the-finalization-group-prototype-object">

--- a/spec/weak-ref.html
+++ b/spec/weak-ref.html
@@ -74,29 +74,6 @@
         [[Enumerable]]: *false*, [[Configurable]]: *false* }.
       </p>
     </emu-clause>
-
-    <emu-clause id="sec-get-weak-ref-@@species">
-      <h1>get WeakRef [ @@species ]</h1>
-
-      <p>
-        `WeakRef[@@species]` is an accessor property whose set
-        accessor function is *undefined*. Its get accessor function
-        performs the following steps:
-      </p>
-
-      <emu-alg>
-        1. Return the *this* value.
-      </emu-alg>
-      <p>The value of the `name` property of this function is `"get [Symbol.species]"`.</p>
-      <emu-note>
-        <p>
-          Methods that create derived collection objects should call
-          @@species to determine the constructor to use to create the
-          derived objects. Subclass constructor may over-ride
-          @@species to change the default constructor assignment.
-        </p>
-      </emu-note>
-    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-properties-of-the-weak-ref-prototype-object">


### PR DESCRIPTION
These constructors' prototypes do not have any method which produces
a WeakRef or FinalizationGroup instance, so there's no need for them
to have this property.