### PR TITLE
Editorial: Clarify that errors are not swallowed

### DIFF
--- a/spec/abstract-jobs.html
+++ b/spec/abstract-jobs.html
@@ -102,6 +102,7 @@
       1. Perform ? Call(_callback_, *undefined*, _iterator_).
       1. Return *undefined*.
     </emu-alg>
+    <emu-note type=editor>If calling the callback throws an error, this will be caught within the RunJobs algorithm and reported to the host. HTML does not apply the RunJobs algorithm, but will also report the error.</emu-note>
   </emu-clause>
 
   <emu-clause id="sec-keepduringjob" aoid="KeepDuringJob">

--- a/spec/abstract-jobs.html
+++ b/spec/abstract-jobs.html
@@ -102,7 +102,7 @@
       1. Perform ? Call(_callback_, *undefined*, _iterator_).
       1. Return *undefined*.
     </emu-alg>
-    <emu-note type=editor>If calling the callback throws an error, this will be caught within the RunJobs algorithm and reported to the host. HTML does not apply the RunJobs algorithm, but will also report the error.</emu-note>
+    <emu-note type=editor>When called from DoAgentFinalization, if calling the callback throws an error, this will be caught within the RunJobs algorithm and reported to the host. HTML does not apply the RunJobs algorithm, but will also <a href="https://html.spec.whatwg.org/#report-the-error">report the error</a>, which may call `window.onerror`.</emu-note>
   </emu-clause>
 
   <emu-clause id="sec-keepduringjob" aoid="KeepDuringJob">


### PR DESCRIPTION
The specification already contains semantics here, but they are a bit obscure, so this patch adds a note that clarifies what happens. The issue was raised at https://bugs.chromium.org/p/v8/issues/detail?id=8179#c30