### PR TITLE
Throw if FinalizationGroupCleanupIterator is iterated outside of the FinalizationGroupCleanupJob

### DIFF
--- a/spec/abstract-jobs.html
+++ b/spec/abstract-jobs.html
@@ -95,12 +95,15 @@
     <h1> FinalizationGroupCleanupJob ( _finalizationGroup_ [ , _callback_ ] ) </h1>
     <p> The following steps are performed: </p>
     <emu-alg>
-      1. Assert: _finalizationGroup_ has [[Cells]] and
-      [[CleanupCallback]] internal slots.
+      1. Assert: _finalizationGroup_ has [[Cells]],
+      [[CleanupCallback]], and [[IsFinalizationGroupCleanupJobActive]] internal slots.
       1. Let _iterator_ be ! CreateFinalizationGroupCleanupIterator(_finalizationGroup_).
       1. If _callback_ is *undefined*, set _callback_ to _finalizationGroup_.[[CleanupCallback]].
-      1. Perform ? Call(_callback_, *undefined*, _iterator_).
-      1. Return *undefined*.
+      1. Set _finalizationGroup_.[[IsFinalizationGroupCleanupJobActive]] to *true*.
+      1. Let _result_ be Call(_callback_, *undefined*, _iterator_).
+      1. Set _finalizationGroup_.[[IsFinalizationGroupCleanupJobActive]] to *false*.
+      1. If _result_ is an abrupt completion, return _result_.
+      1. Else return NormalCompletion(*undefined*).
     </emu-alg>
     <emu-note type=editor>When called from DoAgentFinalization, if calling the callback throws an error, this will be caught within the RunJobs algorithm and reported to the host. HTML does not apply the RunJobs algorithm, but will also <a href="https://html.spec.whatwg.org/#report-the-error">report the error</a>, which may call `window.onerror`.</emu-note>
   </emu-clause>

--- a/spec/finalization-group.html
+++ b/spec/finalization-group.html
@@ -44,9 +44,10 @@
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
         1. If IsCallable(_cleanupCallback_) is *false*, throw a *TypeError* exception.
         1. Let _finalizationGroup_ be ? OrdinaryCreateFromConstructor(NewTarget,
-        `"%FinalizationGroupPrototype%"`, &laquo; [[CleanupCallback]], [[Cells]] &raquo;).
+        `"%FinalizationGroupPrototype%"`, &laquo; [[CleanupCallback]], [[Cells]], [[IsFinalizationGroupCleanupJobActive]] &raquo;).
         1. Set _finalizationGroup_.[[CleanupCallback]] to _cleanupCallback_.
         1. Set _finalizationGroup_.[[Cells]] to be an empty List.
+        1. Set _finalizationGroup_.[[IsFinalizationGroupCleanupJobActive]] to *false*.
         1. Let _agent_ be the surrounding agent.
         1. Append _finalizationGroup_ to _agent_.[[FinalizationGroups]].
         1. Return _finalizationGroup_.
@@ -210,7 +211,9 @@
             1. Let _finalizationGroup_ be _iterator_.[[FinalizationGroup]].
             1. If _finalizationGroup_ is *undefined*, then
               1. Return CreateIterResultObject(*undefined*, *true*).
-            1. Assert: _finalizationGroup_ has [[Cells]] internal slot.
+            1. Assert: _finalizationGroup_ has [[Cells]] and [[IsFinalizationGroupCleanupJobActive]] internal slot.
+            1. If _finalizationGroup_.[[IsFinalizationGroupCleanupJobActive]] is *false*,
+            throw a *TypeError* exception.
             1. If _finalizationGroup_.[[Cells]] contains a Record _cell_ such that _cell_.[[Target]] is ~empty~,
               1. Choose any such _cell_.
               1. Remove _cell_ from _finalizationGroup_.[[Cells]].


### PR DESCRIPTION
Leaking the iterator is bad as we could potentially cause the same holding to be iterated twice if the user iterates over a leaked iterator (from a previous turn) and a newly created iterator (in the following turn).

Fixes https://github.com/tc39/proposal-weakrefs/issues/29