### PR TITLE
Fix history links

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,11 +305,11 @@ Remember to be cautious with use of powerful constructs like this iterable WeakM
 
 ## Historical documents
 
-- [OLD Explanation](https://github.com/tc39/proposal-weakrefs/blob/master/specs/weakrefs.md) of a previous version of the proposal
+- [OLD Explanation](https://github.com/tc39/proposal-weakrefs/blob/master/history/weakrefs.md) of a previous version of the proposal
 - [WeakRefGroups](https://github.com/tc39/proposal-weakrefs/wiki/WeakRefGroups): Previously proposed interface
 - [Support for long wasm jobs](https://github.com/tc39/proposal-weakrefs/wiki/Support-for-long-wasm-jobs): Background on the motivation for the `cleanupSome` method
-- [Previous Spec-text](https://github.com/tc39/proposal-weakrefs/blob/master/specs/spec.md) for an earlier draft of the proposal
-- [Slides](https://github.com/tc39/proposal-weakrefs/blob/master/specs/Weak%20References%20for%20EcmaScript.pdf): Some design considerations that went into this proposal
+- [Previous Spec-text](https://github.com/tc39/proposal-weakrefs/blob/master/history/spec.md) for an earlier draft of the proposal
+- [Slides](https://github.com/tc39/proposal-weakrefs/blob/master/history/Weak%20References%20for%20EcmaScript.pdf): Some design considerations that went into this proposal
 
 ## Champions
 


### PR DESCRIPTION
Old specs was moved to `history` folder in #59 so we fix the old specs related links by changing folder from `specs` to `history`.