### PR TITLE
Fix case in which IterableWeakMap keys() and values() could disagree

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,14 +265,15 @@ class IterableWeakMap {
   }
 
   *keys() {
-    for (const [ref] of this.#refMap) {
-      const key = ref.deref();
-      if (key) yield key;
+    for (const [key, value] of this) {
+      yield key;
     }
   }
 
-  values() {
-    return this.#refMap.values();
+  *values() {
+    for (const [key, value] of this) {
+      yield value;
+    }
   }
 }
 


### PR DESCRIPTION
In the IterableWeakMap example, the values() iterator may return values
that are no longer part of the map, because the iterator doesn't check
if the key is already collected.