### PR TITLE
Revert "Move constructors to the System object"

### DIFF
--- a/spec/finalization-group.html
+++ b/spec/finalization-group.html
@@ -13,7 +13,7 @@
       <li>is the intrinsic object <dfn>%FinalizationGroup%</dfn>.</li>
       <li>
         is the initial value of the `FinalizationGroup` property of
-        the %System% object.
+        the global object.
       </li>
       <li>
         creates and initializes a new FinalizationGroup object when

--- a/spec/weak-ref.html
+++ b/spec/weak-ref.html
@@ -13,7 +13,7 @@
     <ul>
       <li>is the intrinsic object %WeakRef%.</li>
       <li>
-        is the initial value of the `WeakRef` property of the %System%
+        is the initial value of the `WeakRef` property of the global
         object.
       </li>
       <li>


### PR DESCRIPTION
Reverts tc39/proposal-weakrefs#67

There are other mechanisms possible to make it easier to maintain certain virtualization shims, discussed in #22. This mechanism could be part of this proposal, part of another proposal, or implemented in JavaScript (as it is today). In any case, this mechanism could make it not longer needed to use the `System` object for the WeakRef and FinalizationGroup objects.