### PR TITLE
Fix left-overs from layering changes in #86

### DIFF
--- a/spec/abstract-jobs.html
+++ b/spec/abstract-jobs.html
@@ -199,6 +199,6 @@
       1. If _result_ is an abrupt completion, return _result_.
       1. Else return NormalCompletion(*undefined*).
     </emu-alg>
-    <emu-note type=editor>When called from DoAgentFinalization, if calling the callback throws an error, this will be caught within the RunJobs algorithm and reported to the host. HTML does not apply the RunJobs algorithm, but will also <a href="https://html.spec.whatwg.org/#report-the-error">report the error</a>, which may call `window.onerror`.</emu-note>
+    <emu-note type=editor>When called from HostCleanupFinalizationGroup, if calling the callback throws an error, this will be caught within the RunJobs algorithm and reported to the host. HTML does not apply the RunJobs algorithm, but will also <a href="https://html.spec.whatwg.org/#report-the-error">report the error</a>, which may call `window.onerror`.</emu-note>
   </emu-clause>
 </emu-clause>

--- a/spec/abstract-jobs.html
+++ b/spec/abstract-jobs.html
@@ -77,7 +77,7 @@
         <li>
           When an object which is registered with a FinalizationGroup becomes
           unreachable, a call of the FinalizationGroup's cleanup callback may
-          eventually be made, after synchronous JavaScript execution completes.
+          eventually be made, after synchronous ECMAScript execution completes.
           The FinalizationGroup cleanup is performed with the
           CleanupFinalizationGroup abstract operation.
         </li>

--- a/spec/finalization-group.html
+++ b/spec/finalization-group.html
@@ -51,8 +51,6 @@
         1. Set _finalizationGroup_.[[CleanupCallback]] to _cleanupCallback_.
         1. Set _finalizationGroup_.[[Cells]] to be an empty List.
         1. Set _finalizationGroup_.[[IsFinalizationGroupCleanupJobActive]] to *false*.
-        1. Let _AR_ be the Agent Record of the surrounding agent.
-        1. Append _finalizationGroup_ to _AR_.[[FinalizationGroups]].
         1. Return _finalizationGroup_.
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
- Don't add FinalizationGroup instances to the removed Agent Record's `[[FinalizationGroups]]`
- `DoAgentFinalization` no longer exists so it cannot call `CleanupFinalizationGroup`