### PR TITLE
Normative: Refine definition of reachability

### DIFF
--- a/spec/abstract-jobs.html
+++ b/spec/abstract-jobs.html
@@ -120,7 +120,8 @@
             <li>
                 No possible future execution of the program would observably
                 reference the object, except through a chain of references which
-                includes a [[Target]] field or [[Target]] internal slot.
+                includes a [[Target]] field of a FinalizationGroup's [[Cells]] List,
+                or the [[Target]] internal slot of a WeakRef.
               </p>
               <p>
                 NOTE: The exact guarantee remains under discussion in

--- a/spec/abstract-jobs.html
+++ b/spec/abstract-jobs.html
@@ -111,12 +111,24 @@
 
       <ul>
         <li>
-          If all references to a ECMAScript object are from a
-          [[Target]] field or internal slot, including the agent's [[KeptAlive]] field,
-          the implementation may replace the reference to the object in all such
-          [[Target]] fields or internal slots with the value ~empty~.
+          If the following conditions about an ECMAScript object are met, then
+          the implementation may replace each reference to the object from the
+          [[Target]] field of a FinalizationGroup's [[Cells]] List, or the
+          [[Target]] internal slot of a WeakRef, to the value ~empty~:
+          <ul>
+            <li>The object is not included in any agent's [[KeptAlive]] List.</li>
+            <li>
+                No possible future execution of the program would observably
+                reference the object, except through a chain of references which
+                includes a [[Target]] field or [[Target]] internal slot.
+              </p>
+              <p>
+                NOTE: The exact guarantee remains under discussion in
+                <a href="https://github.com/tc39/proposal-weakrefs/issues/115">#115</a>.
+              </p>
+            </li>
+          </ul>
         </li>
-
         <li>
           When there is a FinalizationGroup _fg_ such that
           CheckForEmptyCells(_fg_) is *true*, the implementation may perform


### PR DESCRIPTION
This attempts to address various issues with how reachability
is defined:
- If one WeakRef object points to an object, which points to
  another one, the whole subgraph may be collected, as raised in
  https://gist.github.com/jimblandy/0014dc11233d2d40df922af850b0489a
- An initial provisional definition of collectability is given:
  >   No possible future execution of the program would observably
  >   reference the object, except through a chain of references which
  >   includes a [[Target]] field or [[Target]] internal slot.
  
  This is intended to resolve #31 (by concluding that the impact on
  host specifications is minimal, and spec graph reachability does not
  imply liveness) and provide a starting point for #105
- The wording around 'field or internal slot' is clarified, resolving #115