### PR TITLE
Normative: Fix the definition of liveness for WeakMap and WeakSet

### DIFF
--- a/spec/abstract-jobs.html
+++ b/spec/abstract-jobs.html
@@ -100,6 +100,33 @@
       </p>
     </emu-clause>
 
+    <emu-clause id="sec-liveness">
+      <h1>Liveness</h1>
+
+      An object _obj_ is considered <dfn>live</dfn> if the following conditions
+      are met:
+
+      <ul>
+        <li>_obj_ is not included in any agent's [[KeptAlive]] List.</li>
+        <li>
+          No possible future execution of the program would observably
+          reference _obj_, except through a chain of references which
+          includes a [[Target]] field of a FinalizationGroup's [[Cells]] List,
+          or the [[Target]] internal slot of a WeakRef.
+        </li>
+      </ul>
+      <emu-note>
+        The above definition implies that, if a key in a WeakMap is not live,
+        then its corresponding value is not necessarily live either. Presence
+        of an object as a key in a WeakMap or a member of a WeakSet does not
+        imply that the object is live.
+      </emu-note>
+      <emu-note type=editor>
+        The exact definition of liveness remains under discussion in
+        <a href="https://github.com/tc39/proposal-weakrefs/issues/115">#115</a>.
+      </p>
+    </emu-clause>
+
     <emu-clause id="sec-weakref-execution">
       <h1>Execution</h1>
 
@@ -111,24 +138,10 @@
 
       <ul>
         <li>
-          If the following conditions about an ECMAScript object are met, then
-          the implementation may replace each reference to the object from the
-          [[Target]] field of a FinalizationGroup's [[Cells]] List, or the
-          [[Target]] internal slot of a WeakRef, to the value ~empty~:
-          <ul>
-            <li>The object is not included in any agent's [[KeptAlive]] List.</li>
-            <li>
-                No possible future execution of the program would observably
-                reference the object, except through a chain of references which
-                includes a [[Target]] field of a FinalizationGroup's [[Cells]] List,
-                or the [[Target]] internal slot of a WeakRef.
-              </p>
-              <p>
-                NOTE: The exact guarantee remains under discussion in
-                <a href="https://github.com/tc39/proposal-weakrefs/issues/115">#115</a>.
-              </p>
-            </li>
-          </ul>
+          If an object is not live, then the implementation may replace any
+          reference to the object from the [[Target]] field of a
+          FinalizationGroup's [[Cells]] List, or the [[Target]] internal slot
+          of a WeakRef, to the value ~empty~.
         </li>
         <li>
           When there is a FinalizationGroup _fg_ such that

--- a/spec/abstract-jobs.html
+++ b/spec/abstract-jobs.html
@@ -107,9 +107,9 @@
       are met:
 
       <ul>
-        <li>_obj_ is not included in any agent's [[KeptAlive]] List.</li>
+        <li>_obj_ is included in any agent's [[KeptAlive]] List.</li>
         <li>
-          No possible future execution of the program would observably
+          Any possible future execution of the program could observably
           reference _obj_, except through a chain of references which
           includes a [[Target]] field of a FinalizationGroup's [[Cells]] List,
           or the [[Target]] internal slot of a WeakRef.

--- a/spec/weak-ref.html
+++ b/spec/weak-ref.html
@@ -136,19 +136,24 @@
       internal slot.
     </p>
   </emu-clause>
+</emu-clause>
 
-  <emu-clause id="sec-collection-modifications">
-    <h1>Modifications to collection type definitions</h1>
-    <p>WeakMap and WeakSet keys are not kept alive just because a WeakRef points to them.</p>
+<emu-clause id="sec-collection-modifications">
+  <h1>Modifications to collection type definitions</h1>
+  <emu-note type=editor>
+    WeakMap and WeakSet keys are not kept alive just because a WeakRef points
+    to them. This proposal rephrases the definition of WeakMaps and WeakSets
+    to explain their observable effects on garbage collection, rather than
+    specifying operationally that non-live keys or members are deleted.
+  </emu-note>
 
-    <emu-clause id="sec-weakmap">
-      <h1>WeakMap Objects</h1>
-      <p>WeakMap objects are collections of key/value pairs where the keys are objects and values may be arbitrary ECMAScript language values. A WeakMap may be queried to see if it contains a key/value pair with a specific key, but no mechanism is provided for enumerating the objects it holds as keys. If an object that is being used as the key of a WeakMap key/value pair is only reachable by following a chain of references that start within that WeakMap, <ins>or if all references to a ECMAScript object are from a [[Target]] field or internal slot,</ins> then that key/value pair is inaccessible and is automatically removed from the WeakMap. WeakMap implementations must detect and remove such key/value pairs and any associated resources.</p>
-    </emu-clause>
+  <emu-clause id="sec-weakmap">
+    <h1>WeakMap Objects</h1>
+    <p>WeakMap objects are collections of key/value pairs where the keys are objects and values may be arbitrary ECMAScript language values. A WeakMap may be queried to see if it contains a key/value pair with a specific key, but no mechanism is provided for enumerating the objects it holds as keys. <ins>There is no way for ECMAScript programs to observe the presence of a key in a WeakMap without a reference to that key. This implies that, if an object is not live, and it is present as a WeakMap key, then the implementation may unobservably remove the key-value pair from the WeakMap.</ins> <del>If an object that is being used as the key of a WeakMap key/value pair is only reachable by following a chain of references that start within that WeakMap, then that key/value pair is inaccessible and is automatically removed from the WeakMap. WeakMap implementations must detect and remove such key/value pairs and any associated resources.</del></p>
+  </emu-clause>
 
-    <emu-clause id="sec-weakset">
-      <h1>WeakSet Objects</h1>
-      <p>WeakSet objects are collections of objects. A distinct object may only occur once as an element of a WeakSet's collection. A WeakSet may be queried to see if it contains a specific object, but no mechanism is provided for enumerating the objects it holds. If an object that is contained by a WeakSet is only reachable by following a chain of references that start within that WeakSet, <ins>or if all references to a ECMAScript object are from a [[Target]] field or internal slot,</ins> then that object is inaccessible and is automatically removed from the WeakSet. WeakSet implementations must detect and remove such objects and any associated resources.</p>
-    </emu-clause>
+  <emu-clause id="sec-weakset">
+    <h1>WeakSet Objects</h1>
+    <p>WeakSet objects are collections of objects. A distinct object may only occur once as an element of a WeakSet's collection. A WeakSet may be queried to see if it contains a specific object, but no mechanism is provided for enumerating the objects it holds. <ins>There is no way for ECMAScript programs to observe the presence of an object held in a WeakSet without a reference to that object. This implies that, if an object is not live, and it is held in a WeakSet, then the implementation may unobservably remove the object from the WeakSet.</ins> <del>If an object that is contained by a WeakSet is only reachable by following a chain of references that start within that WeakSet, then that object is inaccessible and is automatically removed from the WeakSet. WeakSet implementations must detect and remove such objects and any associated resources.</del></p>
   </emu-clause>
 </emu-clause>

--- a/spec/weak-ref.html
+++ b/spec/weak-ref.html
@@ -141,10 +141,19 @@
 <emu-clause id="sec-collection-modifications">
   <h1>Modifications to collection type definitions</h1>
   <emu-note type=editor>
-    WeakMap and WeakSet keys are not kept alive just because a WeakRef points
-    to them. This proposal rephrases the definition of WeakMaps and WeakSets
-    to explain their observable effects on garbage collection, rather than
-    specifying operationally that non-live keys or members are deleted.
+    <p>
+      WeakMap and WeakSet keys are not kept alive just because a WeakRef points
+      to them. This proposal rephrases the definition of WeakMaps and WeakSets
+      to explain their observable effects on garbage collection, rather than
+      specifying operationally that non-live keys or members are deleted.
+    </p>
+
+    <p>
+      Open questions remain under discussion about the relationship between when
+      elements are collected in WeakMaps, WeakSets and WeakRefs, e.g.,
+      what guarantees are made about timing, c.f.
+      <a href="https://github.com/tc39/proposal-weakrefs/pull/121#issuecomment-497142235">#121 (comment)</a>.
+    </p>
   </emu-note>
 
   <emu-clause id="sec-weakmap">


### PR DESCRIPTION
This patch rephrases the definition of WeakMaps and WeakSets to
explain their observable effects on garbage collection, rather
than specifying operationally that non-live keys or members are deleted.

It separates out a definition of "live" that can be referenced from
various places. This defintion is based on earlier spec text, in
terms of whether something may be "observably referenced".