### PR TITLE
Amend liveness definition to mean observable object identity.

### DIFF
--- a/spec/abstract-jobs.html
+++ b/spec/abstract-jobs.html
@@ -104,39 +104,45 @@
       <h1>Liveness</h1>
 
       <p>
-        An execution <dfn>eagerly empties WeakRefs</dfn> if it performs the
-        following steps after every step of evaluation.
+        For some object _obj_, a <dfn>hypothetical WeakRef-oblivious</dfn>
+        execution with respect to _obj_ is an execution whereby
+        WeakRef.prototype.deref being called on a WeakRef whose referent is
+        _obj_ always returns *undefined*.
       </p>
-      <emu-alg>
-        1. For each WeakRef _ref_,
-          1. Let _obj_ be _ref_.[[Target]].
-          1. If _obj_ is not included in any agent's [[KeptAlive]] List, then set _ref_.[[Target]] to ~empty~.
-      </emu-alg>
+      <emu-note>
+        WeakRef-obliviousness, together with liveness, capture two
+        notions. One, that a WeakRef itself does not keep an object alive. Two,
+        that cycles in liveness does not imply that an object is live. To be
+        concrete, if determining _obj_'s liveness depends on determining the
+        liveness of another WeakRef referent, _obj2_, _obj2_'s liveness cannot
+        assume _obj_'s liveness, which would beg the question.
+      </emu-note>
 
       <p>
         At any point during evaluation, an object _obj_ is
-        considered <dfn>live</dfn> if the following conditions are met:
+        considered <dfn>live</dfn> if either of the following conditions is
+        met:
       </p>
 
       <ul>
         <li>_obj_ is included in any agent's [[KeptAlive]] List.</li>
         <li>
-          There exists a valid future execution that both eagerly empties
-          WeakRefs and observes the Object value of _obj_.
+          There exists a valid future hypothetical WeakRef-oblivious execution
+          with respect to _obj_ that observes the Object value of _obj_.
         </li>
       </ul>
       <emu-note>
         The intuition the second condition above intends to capture is that an
-        object is live if its identity is observable via non-WeakRef means.
-        For example, an object's identity may be observed by observing a strict
-        equality comparison between objects or observing the object being used
-        as key in a Map.
+        object is live if its identity is observable via non-WeakRef means. An
+        object's identity may be observed by observing a strict equality
+        comparison between objects or observing the object being used as key in
+        a Map.
       </emu-note>
       <emu-note>
-        Presence of an object in an internal slot does not imply that the
-        object is live. For example if the object in the internal slot is never
-        passed back to the program, then it cannot be observed through the
-        internal slot.
+        Presence of an object in a field, an internal slot, or a property does
+        not imply that the object is live. For example if the object in
+        question is never passed back to the program, then it cannot be
+        observed.
 
         This is the case for keys in a WeakMap, members of a WeakSet, as well
         as the [[Target]] and [[UnregisterToken]] fields of a FinalizationGroup
@@ -144,6 +150,12 @@
 
         The above definition implies that, if a key in a WeakMap is not live,
         then its corresponding value is not necessarily live either.
+      </emu-note>
+      <emu-note>
+        Liveness is the lower bound for guaranteeing which WeakRefs that
+        engines must not empty. In practice, liveness as defined here is
+        undecidable and engines use conservative approximations. There is
+        expected to be significant implementation leeway.
       </emu-note>
       <emu-note type=editor>
         The exact definition of liveness remains under discussion in

--- a/spec/abstract-jobs.html
+++ b/spec/abstract-jobs.html
@@ -103,17 +103,27 @@
     <emu-clause id="sec-liveness">
       <h1>Liveness</h1>
 
-      <p>An object _obj_ is considered <dfn>live</dfn> if the following conditions
-      are met:</p>
+      <p>
+        At any point during evaluation, an object _obj_ is
+        considered <dfn>live</dfn> if the following conditions are met:
+      </p>
 
       <ul>
         <li>_obj_ is included in any agent's [[KeptAlive]] List.</li>
         <li>
-          Any possible future execution of the program could observably
-          reference _obj_, except through a chain of references which
-          includes the [[Target]] internal slot of a WeakRef.
+          There exists a valid future execution of the program where, if after
+          every step of evaluation, all WeakRef instances' [[Target]] internal
+          slots whose values are not included in any agent's [[KeptAlive]] List
+          are set to ~empty~, the Object value of _obj_ is observed.
         </li>
       </ul>
+      <emu-note>
+        The intuition the second condition above intends to capture is that an
+        object is live if its identity is observable via non-WeakRef means.
+        For example, an object's identity may be observed by observing a strict
+        equality comparison between objects or observing the object being used
+        as key in a Map.
+      </emu-note>
       <emu-note>
         Presence of an object in an internal slot does not imply that the
         object is live. For example if the object in the internal slot is never
@@ -123,9 +133,9 @@
         This is the case for keys in a WeakMap, members of a WeakSet, as well
         as the [[Target]] and [[UnregisterToken]] fields of a FinalizationGroup
         Cell record.
-        
+
         The above definition implies that, if a key in a WeakMap is not live,
-        then its corresponding value is not necessarily live either. 
+        then its corresponding value is not necessarily live either.
       </emu-note>
       <emu-note type=editor>
         The exact definition of liveness remains under discussion in
@@ -149,6 +159,22 @@
         1. For each WeakSet _set_ such that _set_.[[WeakSetData]] contains _obj_,
           1. Remove _obj_ from _set_.[[WeakSetData]].
       </emu-alg>
+
+      <emu-note>
+        Together with the definition of liveness, this clause prescribes legal
+        optimizations that an implementation may apply regarding WeakRefs.
+
+        It is possible to access an object without observing its
+        identity. Optimizations such as dead variable elimination, and scalar
+        replacement on properties of non-escaping objects whose identity is not
+        observed, are allowed. These optimizations are thus allowed to
+        observably empty WeakRefs that point to such objects.
+
+        On the other hand, if an object's identity is observable, and that
+        object is in the [[Target]] internal slot of a WeakRef, optimizations
+        such as rematerialization that observably empty the WeakRef are
+        prohibited.
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-weakref-host-hooks">

--- a/spec/abstract-jobs.html
+++ b/spec/abstract-jobs.html
@@ -104,6 +104,16 @@
       <h1>Liveness</h1>
 
       <p>
+        An execution <dfn>eagerly empties WeakRefs</dfn> if it performs the
+        following steps after every step of evaluation.
+      </p>
+      <emu-alg>
+        1. For each WeakRef _ref_,
+          1. Let _obj_ be _ref_.[[Target]].
+          1. If _obj_ is not included in any agent's [[KeptAlive]] List, then set _ref_.[[Target]] to ~empty~.
+      </emu-alg>
+
+      <p>
         At any point during evaluation, an object _obj_ is
         considered <dfn>live</dfn> if the following conditions are met:
       </p>
@@ -111,10 +121,8 @@
       <ul>
         <li>_obj_ is included in any agent's [[KeptAlive]] List.</li>
         <li>
-          There exists a valid future execution of the program where, if after
-          every step of evaluation, all WeakRef instances' [[Target]] internal
-          slots whose values are not included in any agent's [[KeptAlive]] List
-          are set to ~empty~, the Object value of _obj_ is observed.
+          There exists a valid future execution that both eagerly empties
+          WeakRefs and observes the Object value of _obj_.
         </li>
       </ul>
       <emu-note>


### PR DESCRIPTION
First stab at #105. @erights @gsathya @littledan @tschneidereit please take a look.


Copy-pasting an email I sent to some folks that captures the intuition of this change:


Consider the following:

```javascript
L1: const o = {};
L2: const wr = new WeakRef(o);
L3: await 1;
L4: assert(wr.deref() === o); // this should never fail
```

One (unlikely) optimization a sufficiently smart compiler may do here is: collect `o` but remember its contents and its identity (i.e. its pointer value) between L3 and L4, and upon evaluating the comparison `wr.defer() === o` on L4, "rematerialize" the object with its original contents all the way down to its identity. If that optimization is applied, the collection of `o` between L3 and L4 may very well cause `wr.deref()` to return null.

It seems desirable to disallow this kind of optimization. In other words, if such "rematerialization+identity" optimizations were allowed, then the engine is free to collect any object at any point, and such an implementation renders the WeakRefs a useless feature.

To be more precise, the constraint highlighted here is something like:

A WeakRef whose [[Target]] is an Object _o_ may be nulled out at any point in evaluation if and only if, with all weak references to _o_  nulled out, there is no execution where the identity of _o_ is observed.

Applied to the above example, we can reason as follows:

- assert observes the result of its argument
- assert's argument is the result wr.deref() === o, so that expression is observed
- the result of that expression depends on the identity of o, so the identity of o is observed
- so weak references to o cannot be nulled out before L4.

The key here is identity. For clarity, the following example *is* permitted by the identity reasoning above:

```javascript
M1: const o = { log() { console.log("side effect"); } };
M2: const wr = new WeakRef(o);
M3: await 1;
M4: assert(wr.deref() !== null); // this could fail
M5: o.log();
```

In this example, even though `o` has an observably effectful method "log", `o`'s *identity* is never observed. Escape analysis and something like scalar replacement applied to methods *should be* allowed to inline `o.log` directly at M5, and allow the WeakRef to `o` be nulled out.