### PR TITLE
Normative: cleanupSome to re-throw CleanupFinalizationGroup errors

### DIFF
--- a/spec/finalization-group.html
+++ b/spec/finalization-group.html
@@ -150,7 +150,7 @@
         internal slot, throw a *TypeError* exception.
         1. If _callback_ is not *undefined* and IsCallable(_callback_) is
         *false*, throw a *TypeError* exception.
-        1. Perform ! CleanupFinalizationGroup(_finalizationGroup_, _callback_).
+        1. Perform ? CleanupFinalizationGroup(_finalizationGroup_, _callback_).
         1. Return *undefined*.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
`CleanupFinalizationGroup` can result in an abrupt completion (when the user provided callback throws) so the job should be called with `?` instead of `!` to bubble the error back.