### PR TITLE
Normative: FinalizationGroup with non-empty cell is live

### DIFF
--- a/spec/abstract-jobs.html
+++ b/spec/abstract-jobs.html
@@ -113,6 +113,10 @@
           reference _obj_, except through a chain of references which
           includes the [[Target]] internal slot of a WeakRef.
         </li>
+        <li>
+          _obj_ is a FinalizationGroup instance such that _obj_.[[Cells]]
+           contains a _cell_, such that _cell_.[[Target]] is not ~empty~.
+        </li>
       </ul>
       <emu-note>
         Presence of an object in an internal slot does not imply that the


### PR DESCRIPTION
Extend the definition of liveness to include FinalizationGroup instances with non-empty cells.

Even though the FinalizationGroup object itself is no longer reachable, developers expect the `cleanupCallback` to be invoked when already registered targets get garbage collected.

The FinalizationGroup instance may be collected if it only contains empty cells.\
The expectation is that it would only happen after `HostCleanupFinalizationGroup`, i.e. that the cleanupCallback was invoked and that the developer had a chance to perform cleanup for the last emptied cells.\
There is nothing actually enforcing this in the text, I'm not sure how to word this requirement.

The reason to not simply collect FinalizationGroup instances with an empty *cell list* is that empty cells are only removed from the list when consumed by the iterator. If the developer doesn't consume the iterator, the FinalizationGroup would leak.

Fixes #66 