### PR TITLE
Normative: not live FinalizationGroup included in Execution

### DIFF
--- a/spec/abstract-jobs.html
+++ b/spec/abstract-jobs.html
@@ -195,6 +195,20 @@
         such as rematerialization that observably empty the WeakRef are
         prohibited.
       </emu-note>
+
+      <emu-note>
+        Every FinalizationGroup instance must be considered for cells to
+        empty in step 2., regardless of the liveness of the FinalizationGroup.
+
+        Furthermore, during an Execution, if the implementation would perform
+        HostCleanupFinalizationGroup(_fg_) in step 2.b. for a live
+        FinalizationGroup, it must perform HostCleanupFinalizationGroup(_fg_)
+        in that Execution for a FinalizationGroup that is not live.
+
+        A program with two FinalizationGroup, one live and one not, should
+        observe either both or neither cleanup callback being called after the
+        same object registered with them becomes unreachable.
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-weakref-host-hooks">


### PR DESCRIPTION
Require implementations to treat FinalizationGroup objects the same during the Execution, whether they are live or not.\
The goal is to make sure that the cleanup callback is invoked for an un-referenced FinalizationGroup if it would have been invoked had the FinalizationGroup been referenced.

Implementations can accomplish this by keeping FinalizationGroup objects alive while they have non-empty cells. After the discussion in #146, it became clear that the spec couldn't word it that way because performing the HostCleanupFinalizationGroup job is optional. This PR instead puts conditions on the optionality.

Fixes #66.