### PR TITLE
Normative: cleanupSome throw if cleanup job active

### DIFF
--- a/spec/finalization-group.html
+++ b/spec/finalization-group.html
@@ -149,8 +149,10 @@
         1. Let _finalizationGroup_ be the *this* value.
         1. If Type(_finalizationGroup_) is not Object, throw a
         *TypeError* exception.
-        1. If _finalizationGroup_ does not have a [[Cells]]
-        internal slot, throw a *TypeError* exception.
+        1. If _finalizationGroup_ does not have [[Cells]] and [[IsFinalizationGroupCleanupJobActive]]
+        internal slots, throw a *TypeError* exception.
+        1. If _finalizationGroup_.[[IsFinalizationGroupCleanupJobActive]] is *true*,
+        throw a *TypeError* exception.
         1. If _callback_ is not *undefined* and IsCallable(_callback_) is
         *false*, throw a *TypeError* exception.
         1. Perform ? CleanupFinalizationGroup(_finalizationGroup_, _callback_).


### PR DESCRIPTION
Prevent re-entrancy by checking there is no active cleanup job in `cleanupSome`. Fixes #152