### PR TITLE
Normative: empty iterator's [[FinalizationGroup]] slot after cleanup job

### DIFF
--- a/spec/abstract-jobs.html
+++ b/spec/abstract-jobs.html
@@ -268,6 +268,7 @@
       1. Set _finalizationGroup_.[[IsFinalizationGroupCleanupJobActive]] to *true*.
       1. Let _result_ be Call(_callback_, *undefined*, &laquo; _iterator_ &raquo;).
       1. Set _finalizationGroup_.[[IsFinalizationGroupCleanupJobActive]] to *false*.
+      1. Set _iterator_.[[FinalizationGroup]] to ~empty~.
       1. If _result_ is an abrupt completion, return _result_.
       1. Else, return NormalCompletion(*undefined*).
     </emu-alg>

--- a/spec/finalization-group.html
+++ b/spec/finalization-group.html
@@ -149,8 +149,10 @@
         1. Let _finalizationGroup_ be the *this* value.
         1. If Type(_finalizationGroup_) is not Object, throw a
         *TypeError* exception.
-        1. If _finalizationGroup_ does not have a [[Cells]]
-        internal slot, throw a *TypeError* exception.
+        1. If _finalizationGroup_ does not have [[Cells]] and [[IsFinalizationGroupCleanupJobActive]]
+        internal slots, throw a *TypeError* exception.
+        1. If _finalizationGroup_.[[IsFinalizationGroupCleanupJobActive]] is *true*,
+        throw a *TypeError* exception.
         1. If _callback_ is not *undefined* and IsCallable(_callback_) is
         *false*, throw a *TypeError* exception.
         1. Perform ? CleanupFinalizationGroup(_finalizationGroup_, _callback_).

--- a/spec/finalization-group.html
+++ b/spec/finalization-group.html
@@ -220,11 +220,11 @@
             1. If Type(_iterator_) is not Object, throw a *TypeError* exception.
             1. If _iterator_ does not have a [[FinalizationGroup]] internal slot,
             throw a *TypeError* exception.
+            1. If _iterator_.[[FinalizationGroup]] is ~empty~,
+            throw a *TypeError* exception.
             1. Let _finalizationGroup_ be _iterator_.[[FinalizationGroup]].
             1. Assert: Type(_finalizationGroup_) is Object.
-            1. Assert: _finalizationGroup_ has [[Cells]] and [[IsFinalizationGroupCleanupJobActive]] internal slots.
-            1. If _finalizationGroup_.[[IsFinalizationGroupCleanupJobActive]] is *false*,
-            throw a *TypeError* exception.
+            1. Assert: _finalizationGroup_ has a [[Cells]] internal slot.
             1. If _finalizationGroup_.[[Cells]] contains a Record _cell_ such that _cell_.[[Target]] is ~empty~,
               1. Choose any such _cell_.
               1. Remove _cell_ from _finalizationGroup_.[[Cells]].


### PR DESCRIPTION
Guard the iterator by checking if it's still related to a FinalizationGroup object.
After the cleanup callback invocation, empty the iterator's FinalizationGroup slot to make it unusable.
Fixes #151 

Based on #158 which fixes #152.

Alternative to #153 