### PR TITLE
Editorial: rename `holdings` to `heldValue`

### DIFF
--- a/spec/abstract-jobs.html
+++ b/spec/abstract-jobs.html
@@ -95,7 +95,7 @@
         Some ECMAScript implementations include garbage collector implementations
         which run in the background, including when ECMAScript is idle. Letting the
         embedding environment schedule CleanupFinalizationGroup allows it to resume
-        ECMAScript execution in order to run finalizer work, which may free up holdings,
+        ECMAScript execution in order to run finalizer work, which may free up held values,
         reducing overall memory usage.
       </p>
     </emu-clause>

--- a/spec/finalization-group.html
+++ b/spec/finalization-group.html
@@ -103,7 +103,7 @@
     </emu-clause>
 
     <emu-clause id="sec-finalization-group.prototype.register">
-      <h1>FinalizationGroup.prototype.register ( _target_ , _holdings_ [, _unregisterToken_ ]  )</h1>
+      <h1>FinalizationGroup.prototype.register ( _target_ , _heldValue_ [, _unregisterToken_ ]  )</h1>
       <p>The following steps are taken:</p>
       <emu-alg>
         1. Let _finalizationGroup_ be the *this* value.
@@ -111,12 +111,11 @@
         1. If _finalizationGroup_ does not have a [[Cells]] internal slot,
         throw a *TypeError* exception.
         1. If Type(_target_) is not Object, throw a *TypeError* exception.
-        1. If SameValue(_target_, _holdings_), throw a *TypeError* exception.
+        1. If SameValue(_target_, _heldValue_), throw a *TypeError* exception.
         1. If Type(_unregisterToken_) is not Object,
           1. If _unregisterToken_ is not *undefined*, throw a *TypeError* exception.
           1. Set _unregisterToken_ to ~empty~.
-        1. Let _cell_ be the Record { [[Target]] : _target_, [[Holdings]]:
-        _holdings_, [[UnregisterToken]]: _unregisterToken_ }.
+        1. Let _cell_ be the Record { [[Target]] : _target_, [[HeldValue]]: _heldValue_, [[UnregisterToken]]: _unregisterToken_ }.
         1. Append _cell_ to _finalizationGroup_.[[Cells]].
         1. Return *undefined*.
       </emu-alg>
@@ -133,7 +132,7 @@
         internal slot, throw a *TypeError* exception.
         1. If Type(_unregisterToken_) is not Object, throw a *TypeError* exception.
         1. Let _removed_ be *false*.
-        1. For each Record { [[Target]], [[Holdings]],
+        1. For each Record { [[Target]], [[HeldValue]],
         [[UnregisterToken]] } _cell_ that is an element of
         _finalizationGroup_.[[Cells]], do
           1. If SameValue(_cell_.[[UnregisterToken]], _unregisterToken_) is *true*, then
@@ -229,7 +228,7 @@
             1. If _finalizationGroup_.[[Cells]] contains a Record _cell_ such that _cell_.[[Target]] is ~empty~,
               1. Choose any such _cell_.
               1. Remove _cell_ from _finalizationGroup_.[[Cells]].
-              1. Return CreateIterResultObject(_cell_.[[Holdings]], *false*).
+              1. Return CreateIterResultObject(_cell_.[[HeldValue]], *false*).
             1. Otherwise, return CreateIterResultObject(*undefined*, *true*).
           </emu-alg>
      </emu-clause>


### PR DESCRIPTION
Fixes #113.

Bikesheds welcome; originally I was going to go with "holding" but it sounded weird. "heldValue" to me more properly describes a noun, and a single value.