### PR TITLE
Remove obsolete editor's notes

### DIFF
--- a/spec/abstract-jobs.html
+++ b/spec/abstract-jobs.html
@@ -157,10 +157,6 @@
         undecidable and engines use conservative approximations. There is
         expected to be significant implementation leeway.
       </emu-note>
-      <emu-note type=editor>
-        The exact definition of liveness remains under discussion in
-        <a href="https://github.com/tc39/proposal-weakrefs/issues/115">#115</a>.
-      </p>
     </emu-clause>
 
     <emu-clause id="sec-weakref-execution">

--- a/spec/weak-ref.html
+++ b/spec/weak-ref.html
@@ -164,13 +164,6 @@
       to explain their observable effects on garbage collection, rather than
       specifying operationally that non-live keys or members are deleted.
     </p>
-
-    <p>
-      Open questions remain under discussion about the relationship between when
-      elements are collected in WeakMaps, WeakSets and WeakRefs, e.g.,
-      what guarantees are made about timing, c.f.
-      <a href="https://github.com/tc39/proposal-weakrefs/pull/121#issuecomment-497142235">#121 (comment)</a>.
-    </p>
   </emu-note>
 
   <emu-clause id="sec-weakmap">


### PR DESCRIPTION
* Remove editor's note about definition of liveness still being under discussion, as issue #115 is now closed (as is #105, which probably should have been the issue referenced).

* Remove from editor's note a paragraph about open questions about the relationship between collection of elements in WeakMaps, WeakSets and WeakRefs.  The referenced PR comment appears to have been resolved along with issue #105.