### PR TITLE
Don't pass key as unregister token

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ function makeWeakCached(f) {
 
     const fresh = f(key);
     cache.set(key, new WeakRef(fresh));
-    cleanup.register(fresh, key, key);
+    cleanup.register(fresh, key);
     return fresh;
   };
 }


### PR DESCRIPTION
In `makeWeakCached`, don't pass the key as an unregister token. Fixes #189.