### PR TITLE
Add note that Firefox Night still calls it `FinalizationGroup`

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,5 +372,5 @@ The WeakRefs proposal guarantees that multiple calls to `WeakRef.prototype.deref
 ## Status
 
 * WeakRefs are now Stage 3
-* [Available behind the `javascript.options.experimental.weakrefs` flag in Firefox Nightly]
+* Available behind the `javascript.options.experimental.weakrefs` `about:config` flag in Firefox Nightly (currently uses the old name for `FinalizationRegistry`: "`FinalizationGroup`").
 * [Available behind the `--harmony-weak-refs` flag in V8, by Marja Hölttä](https://bugs.chromium.org/p/v8/issues/detail?id=8179)


### PR DESCRIPTION
Just to save others time if wondering why `FinalizationRegistry` doesn't work in Firefox Nightly yet. Latest nightly, 75.0a1, still uses the name `FinalizationGroup`.