### PR TITLE
Editorial: Fix another `IterableWeakMap` leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,26 +243,36 @@ class IterableWeakMap {
     set.delete(ref);
   }
 
-  constructor(iterable) {
-    for (const [key, value] of iterable) {
-      this.set(key, value);
+  constructor(iterable = null) {
+    if (iterable !== null) {
+      for (const { 0: key, 1: value } of iterable) {
+        this.set(key, value);
+      }
     }
   }
 
   set(key, value) {
-    const ref = new WeakRef(key);
+    const entry = this.#weakMap.get(key);
+    if (entry) {
+      entry.value = value;
+    } else {
+      const ref = new WeakRef(key);
 
-    this.#weakMap.set(key, { value, ref });
-    this.#refSet.add(ref);
-    this.#finalizationGroup.register(key, {
-      set: this.#refSet,
-      ref
-    }, ref);
+      this.#weakMap.set(key, { value, ref });
+      this.#refSet.add(ref);
+      this.#finalizationGroup.register(key, {
+        set: this.#refSet,
+        ref
+      }, ref);
+    }
   }
 
   get(key) {
-    const entry = this.#weakMap.get(key);
-    return entry && entry.value;
+    return this.#weakMap.get(key)?.value;
+  }
+
+  has(key) {
+    return this.#weakMap.has(key);
   }
 
   delete(key) {
@@ -291,13 +301,13 @@ class IterableWeakMap {
   }
 
   *keys() {
-    for (const [key, value] of this) {
+    for (const { 0: key } of this) {
       yield key;
     }
   }
 
   *values() {
-    for (const [key, value] of this) {
+    for (const { 1: value } of this) {
       yield value;
     }
   }


### PR DESCRIPTION
Fixes: <https://github.com/tc39/proposal-weakrefs/issues/213>

This would cause the `#refSet` to possibly contain dead references and lead to a key/value pair being yielded multiple times.

```js
const m = new IterableWeakMap();
const a = { [Symbol.toStringTag]: "A" };
const b = { [Symbol.toStringTag]: "B" };
m.set(a, 1);
m.set(b, 2);
m.set(a, 3);

for (const { 0: key, 1: value } of m) {
	// This would previously log:
	// [object A] 3
	// [object B] 2
	// [object A] 3
	console.log(key, value);
}
```

It also applies some fixes so that `new IterableWeakMap()` doesn’t throw a `TypeError`, because `undefined` is not iterable.

It also makes `IterableWeakMap.length === WeakMap.length`.